### PR TITLE
chore: package.json이 변경 될 때마다 `npm install`을 자동 실행

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -11,3 +11,19 @@ pre-commit:
       run: npx eslint --fix {staged_files}
       glob: '*.{js,jsx}'
       stage_fixed: true
+
+post-merge:
+  files: 'git diff --name-only ORIG_HEAD HEAD'
+  commands:
+    npm-install:
+      run: npm install
+      glob: 'package.json'
+      fail_text: 'npm install failed'
+
+post-checkout:
+  files: 'git diff --name-only HEAD@\{1\} HEAD'
+  commands:
+    npm-install:
+      run: npm install
+      glob: 'package.json'
+      fail_text: 'npm install failed'


### PR DESCRIPTION
실수로 `npm install`을 실행하지 않는 것을 방지하기 위해 새로운 훅을 추가했습니다.

이 변경 사항을 받은 후, 최초 1회는 `npm install`을 실행해야합니다.