### PR TITLE
fix: NavLink의 기본 동작과 겹치는 className 속성 제거

### DIFF
--- a/src/shared/ui/navigation-view.jsx
+++ b/src/shared/ui/navigation-view.jsx
@@ -5,20 +5,10 @@ export function NavigationView() {
     <nav>
       <ul>
         <li>
-          <NavLink
-            to="/"
-            className={({ isActive }) => (isActive ? 'active' : '')}
-          >
-            Home
-          </NavLink>
+          <NavLink to="/">Home</NavLink>
         </li>
         <li>
-          <NavLink
-            to="/about"
-            className={({ isActive }) => (isActive ? 'active' : '')}
-          >
-            About
-          </NavLink>
+          <NavLink to="/about">About</NavLink>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
[NavLink](https://reactrouter.com/start/declarative/navigating#navlink)의 활성화 되면 `active` 클래스를 붙이는 기본 동작과 같은 동작을 하는 코드를 제거했습니다.
