### PR TITLE
docs: useAuth에 JSDoc 추가

### DIFF
--- a/src/shared/auth/auth-context.jsx
+++ b/src/shared/auth/auth-context.jsx
@@ -2,6 +2,18 @@ import { createContext, useContext } from 'react';
 
 export const AuthContext = createContext();
 
+/**
+ * @typedef {object} Auth
+ * @prop {boolean} isAuthenticated 로그인 여부
+ * @prop {(userId: string, password: string) => Promise<{ success: true; error?: never; } | { success: false; error: unknown; }>} login 로그인 함수
+ * @prop {() => void} logout 로그아웃 함수
+ * @prop {() => string | null} getAccessToken accessToken을 가져오는 함수. 없다면 null이 반환됨
+ */
+
+/**
+ * Auth 관련 커스텀 훅입니다.
+ * @returns {Auth}
+ */
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (!context) {


### PR DESCRIPTION
<img width="631" height="175" alt="Code_ejFnKE0eAF" src="https://github.com/user-attachments/assets/c0e8e8e2-9020-435d-ae40-844768522610" />

코드 힌트를 위해 JSDoc을 작성했습니다.

```jsx
import { useAuth } from "@/shared/auth/auth-context.jsx";
// 컴포넌트 안
const auth = useAuth();
auth. // .까지 입력하면 사용할 수 있는 필드가 힌트로 나옵니다.
```

