### PR TITLE
회원가입 유효성 검사 추가 구현

### DIFF
--- a/src/pages/join/components/user-info-step.jsx
+++ b/src/pages/join/components/user-info-step.jsx
@@ -122,6 +122,7 @@ export const UserInfoStep = ({
           value={formData.userAddress}
           onChange={handleChange('userAddress')}
           hasError={formErrors.userAddress}
+          errorMessage={formErrors.userAddress}
           required={true}
         />
 

--- a/src/pages/join/hooks/use-form.jsx
+++ b/src/pages/join/hooks/use-form.jsx
@@ -4,10 +4,15 @@ export function useForm(initialFormData) {
   const [formData, setFormData] = useState(initialFormData);
   const [formErrors, setFormErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
+  const [isIdChecked, setIsIdChecked] = useState(false);
 
   const handleChange = (field) => (e) => {
     setFormData((prev) => ({ ...prev, [field]: e.target.value }));
     setFormErrors((prev) => ({ ...prev, [field]: false }));
+
+    if (field === 'userId') {
+      setIsIdChecked(false);
+    }
   };
 
   const formatPhoneNumber = (number) => {
@@ -61,6 +66,11 @@ export function useForm(initialFormData) {
   const validate = () => {
     const errors = {};
     let hasAnyError = false;
+
+    if (formData.userId && !isIdChecked) {
+      errors.userId = '필수입력란 입니다.';
+      hasAnyError = true;
+    }
 
     const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
     if (formData.userPw && !pwRegex.test(formData.userPw)) {
@@ -229,5 +239,7 @@ export function useForm(initialFormData) {
     validate,
     submitRegistration,
     isLoading,
+    isIdChecked,
+    setIsIdChecked,
   };
 }

--- a/src/pages/join/hooks/use-form.jsx
+++ b/src/pages/join/hooks/use-form.jsx
@@ -78,6 +78,22 @@ export function useForm(initialFormData) {
       hasAnyError = true;
     }
 
+    if (formData.userName) {
+      const name = formData.userName;
+      const nameRegex = /^[가-힣a-zA-Z]{1,6}$/;
+
+      const hasOnlyHangulJamo = /^[ㄱ-ㅎㅏ-ㅣ]+$/.test(name);
+      const hasIncompleteHangul = [...name].some(
+        (char) =>
+          (char >= 'ㄱ' && char <= 'ㅎ') || (char >= 'ㅏ' && char <= 'ㅣ')
+      );
+
+      if (!nameRegex.test(name) || hasOnlyHangulJamo || hasIncompleteHangul) {
+        errors.userName = '필수입력란 입니다.';
+        hasAnyError = true;
+      }
+    }
+
     if (formData.userNumber) {
       const phoneRegex = /^\d+$/;
       const userNumberStr = formData.userNumber.toString();

--- a/src/pages/join/hooks/use-form.jsx
+++ b/src/pages/join/hooks/use-form.jsx
@@ -103,6 +103,21 @@ export function useForm(initialFormData) {
       }
     }
 
+    if (formData.userAddress) {
+      const allowedPattern = /^[a-zA-Z0-9가-힣\s\-#./()~`]*$/;
+      const onlyConsonantVowelPattern = /^[ㄱ-ㅎㅏ-ㅣ]+$/;
+
+      if (formData.userAddress.detail) {
+        if (onlyConsonantVowelPattern.test(formData.userAddress.detail)) {
+          errors.userAddress = '상세주소를 확인해주세요.';
+          hasAnyError = true;
+        } else if (!allowedPattern.test(formData.userAddress.detail)) {
+          errors.userAddress = '특수문자는 -, #, ., /, ( ), ~, `만 가능합니다.';
+          hasAnyError = true;
+        }
+      }
+    }
+
     if (formData.userBirth) {
       const birthDateStr = formData.userBirth.toString();
       const birthDateRegex =

--- a/src/pages/join/hooks/use-form.jsx
+++ b/src/pages/join/hooks/use-form.jsx
@@ -62,7 +62,7 @@ export function useForm(initialFormData) {
     const errors = {};
     let hasAnyError = false;
 
-    const pwRegex = /^[A-Za-z0-9]{6,20}$/;
+    const pwRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{6,20}$/;
     if (formData.userPw && !pwRegex.test(formData.userPw)) {
       errors.userPw =
         '영문, 숫자 포함 6~20자리 구성, 특수기호 제외 입력해주세요.';

--- a/src/pages/join/join-page.jsx
+++ b/src/pages/join/join-page.jsx
@@ -1,30 +1,13 @@
 import styles from './join-page.module.css';
 import { useForm } from './hooks/use-form';
-
 import { useState } from 'react';
-
 import { TermsStep } from './components/terms-step';
 import { UserInfoStep } from './components/user-info-step';
 import { JoinSuccessStep } from './components/join-success-step';
 
 export function JoinPage() {
   const [currentStep, setCurrentStep] = useState(1);
-  const [isIdChecked, setIsIdChecked] = useState(false);
   const [agreeAll, setAgreeAll] = useState(false);
-
-  const requiredFields = [
-    'userId',
-    'userPw',
-    'pwCheck',
-    'userName',
-    'userNumber',
-    'userBirth',
-    'emailId',
-    'emailDomain',
-    'userAddress',
-    'receiveEmail',
-    'receiveSMS',
-  ];
 
   const initialFormData = {
     userId: '',
@@ -40,8 +23,15 @@ export function JoinPage() {
     receiveSMS: '',
   };
 
-  const { formData, formErrors, handleChange, validate, submitRegistration } =
-    useForm(requiredFields, initialFormData);
+  const {
+    formData,
+    formErrors,
+    handleChange,
+    validate,
+    submitRegistration,
+    setIsIdChecked,
+  } = useForm(initialFormData);
+
   const [agreeError, setAgreeError] = useState(false);
 
   const handleNext = async () => {
@@ -57,11 +47,10 @@ export function JoinPage() {
     }
 
     if (currentStep === 2) {
-      const isValid = validate({ isIdChecked });
+      const isValid = validate();
       if (!isValid) return;
 
       const result = await submitRegistration();
-
       if (result.success) {
         window.scrollTo(0, 0);
         setCurrentStep(3);


### PR DESCRIPTION
1. 아이디 중복 검사
- 중복검사 버튼 미입력시 회원가입 실패
2. 성명 
- 6자 이하 한글만 가능 (모음/자음만 있을 시 회원가입 실패)
3. 비밀번호 
- 영문 + 숫자 조합
4. 상세주소 
- [- # , / ( ) ~ `]제외한 특수문자 입력시 유효성 메시지 출력 (모음/자음만 있을 시 회원가입 실패)